### PR TITLE
Removed dobule tag definition to avoid warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,6 @@
 # set limits.conf
 - name: limits.conf tuning
   lineinfile: dest=/etc/security/limits.conf line="{{ item }}" 
-  tags: elasticsearch
   with_items:
     - 'elasticsearch soft nofile 32000'
     - 'elasticsearch hard nofile 32000'


### PR DESCRIPTION
In the `tasks/main.yml` there is a double `tag` key that makes ansible throw a warning.

![1__thanks_for_flying_vim__bash_](https://cloud.githubusercontent.com/assets/1532900/16250487/0e617a00-381e-11e6-9d27-3271eb2936af.png)
