### PR TITLE
Fix plugin listing and installation commands

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,11 +1,11 @@
 ---
 
 - name: get installed Elasticsearch plugins list
-  command: "bin/plugin list chdir=/usr/share/elasticsearch"
+  command: "bin/plugin --list chdir=/usr/share/elasticsearch"
   changed_when: false
   register: es_installed_plugins
 
 - name: install Elasticsearch plugins
-  command: "bin/plugin install {{item.path}} chdir=/usr/share/elasticsearch"
+  command: "bin/plugin --install {{item.path}} chdir=/usr/share/elasticsearch"
   with_items: "{{es_install_plugins}}"
   when: "'- {{item.name}}' not in es_installed_plugins.stdout"


### PR DESCRIPTION
Otherwise it throws the following error message

`Usage:
    -u, --url     [plugin location]   : Set exact URL to download the plugin from
    -i, --install [plugin name]       : Downloads and installs listed plugins [*]
    -t, --timeout [duration]          : Timeout setting: 30s, 1m, 1h... (infinite by default)
    -r, --remove  [plugin name]       : Removes listed plugins
    -l, --list                        : List installed plugins
    -v, --verbose                     : Prints verbose messages
    -s, --silent                      : Run in silent mode
    -h, --help                        : Prints this help message
 [*] Plugin name could be:
     elasticsearch/plugin/version for official elasticsearch plugins (download from download.elasticsearch.org)
     groupId/artifactId/version   for community plugins (download from maven central or oss sonatype)
     username/repository          for site plugins (download from github master)
Message:
   Command [list] unknown.`