### PR TITLE
Fix arguments for elasticsearch 2.x plugin command.

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,11 +1,19 @@
 ---
+- set_fact:
+    es_arg_prefix: ""
+    es_version: "{{ es_version | string }}"
+
+# Arguments prefix for 1.x
+- set_fact:
+    es_arg_prefix: "--"
+  when: es_version[0] == "1"
 
 - name: get installed Elasticsearch plugins list
-  command: "bin/plugin --list chdir=/usr/share/elasticsearch"
+  command: "bin/plugin {{ es_arg_prefix }}list chdir=/usr/share/elasticsearch"
   changed_when: false
   register: es_installed_plugins
 
 - name: install Elasticsearch plugins
-  command: "bin/plugin --install {{item.path}} chdir=/usr/share/elasticsearch"
+  command: "bin/plugin {{ es_arg_prefix }}install {{item.path}} chdir=/usr/share/elasticsearch"
   with_items: "{{es_install_plugins}}"
   when: "'- {{item.name}}' not in es_installed_plugins.stdout"


### PR DESCRIPTION
Commit befa383b312a11a8447901c1f64f699e94648b94 fixed arguments for 1.x but broke them for 2.x. This one works for both.