### PR TITLE
Update apt cache when the elasticsearch repository has changed.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,8 +6,8 @@
 - name: adding elasticsearch gpg key
   apt_key: url="{{es_apt_gpg_url}}" state=present
 
-- name: add elasticsearch repository 
-  apt_repository: repo="{{es_apt_repo}}" state=present
+- name: add elasticsearch repository
+  apt_repository: repo="{{es_apt_repo}}" state=present update_cache=yes
 
 - name: install elasticsearch
   apt: name=elasticsearch state=present update_cache=yes cache_valid_time=3600


### PR DESCRIPTION
Fixes role failure when installing 2.x after 1.7 or vice versa.